### PR TITLE
Fix urllib.quote_plus importation

### DIFF
--- a/maltiverse/maltiverse.py
+++ b/maltiverse/maltiverse.py
@@ -6,7 +6,6 @@ import json
 import requests
 import hashlib
 import jwt
-from urllib import quote_plus
 
 import base64
 


### PR DESCRIPTION
This change needs to be done in order to support python3.

```
try:
    from urllib import quote_plus  # Python 2.X
except ImportError:
    from urllib.parse import quote_plus  # Python 3+
```

Anyway, this library is not even used in this file so it's better to get rid of the importation