### PR TITLE
Add optional enqueue_ingestion param to IOC PUT methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.9
+- Adds support for the new optional IOC PUT query parameter enqueue_ingestion across the Python client.
+
 ## 1.2.8
 - Add a short PUT timeout to avoid long stalls during bulk uploads when backend failures occur.
 

--- a/maltiverse/maltiverse.py
+++ b/maltiverse/maltiverse.py
@@ -40,11 +40,18 @@ class Maltiverse:
             self._sanitize_blacklist(payload)
         return json.dumps(payload)
 
-    def _prepare_put_params(self, index_scope: t.Optional[T_AdminIndexScope] = None):
-        """Prepare query params for PUT requests (index_scope is query-level)."""
+    def _prepare_put_params(
+        self,
+        index_scope: t.Optional[T_AdminIndexScope] = None,
+        enqueue_ingestion: t.Optional[bool] = None,
+    ):
+        """Prepare query params for PUT requests."""
+        params = {}
         if self.admin and index_scope is not None:
-            return {"index_scope": index_scope}
-        return {}
+            params["index_scope"] = index_scope
+        if enqueue_ingestion is not None:
+            params["enqueue_ingestion"] = enqueue_ingestion
+        return params
 
     def _sanitize_blacklist(self, params):
         """Clean restricted fields and add required information to the blacklist."""
@@ -102,13 +109,20 @@ class Maltiverse:
         """Fetch information for a given IP address."""
         return self._request("GET", f"{self.endpoint}/ip/{ip_addr}")
 
-    def ip_put(self, ip_dict: dict, index_scope: t.Optional[T_AdminIndexScope] = None):
+    def ip_put(
+        self,
+        ip_dict: dict,
+        index_scope: t.Optional[T_AdminIndexScope] = None,
+        enqueue_ingestion: t.Optional[bool] = None,
+    ):
         """Update or insert an IP address observable."""
         return self._request(
             "PUT",
             f"{self.endpoint}/ip/{ip_dict['ip_addr']}",
             headers=self._update_headers({"Content-Type": "application/json"}),
-            params=self._prepare_put_params(index_scope=index_scope),
+            params=self._prepare_put_params(
+                index_scope=index_scope, enqueue_ingestion=enqueue_ingestion
+            ),
             data=self.prepare_put_payload(ip_dict),
         )
 
@@ -121,14 +135,19 @@ class Maltiverse:
         return self._request("GET", f"{self.endpoint}/hostname/{hostname}")
 
     def hostname_put(
-        self, hostname_dict: dict, index_scope: t.Optional[T_AdminIndexScope] = None
+        self,
+        hostname_dict: dict,
+        index_scope: t.Optional[T_AdminIndexScope] = None,
+        enqueue_ingestion: t.Optional[bool] = None,
     ):
         """Update or insert a hostname observable."""
         return self._request(
             "PUT",
             f"{self.endpoint}/hostname/{hostname_dict['hostname']}",
             headers=self._update_headers({"Content-Type": "application/json"}),
-            params=self._prepare_put_params(index_scope=index_scope),
+            params=self._prepare_put_params(
+                index_scope=index_scope, enqueue_ingestion=enqueue_ingestion
+            ),
             data=self.prepare_put_payload(hostname_dict),
         )
 
@@ -146,7 +165,10 @@ class Maltiverse:
         return self._request("GET", f"{self.endpoint}/url/{urlchecksum}")
 
     def url_put(
-        self, url_dict: dict, index_scope: t.Optional[T_AdminIndexScope] = None
+        self,
+        url_dict: dict,
+        index_scope: t.Optional[T_AdminIndexScope] = None,
+        enqueue_ingestion: t.Optional[bool] = None,
     ):
         """Update or insert a URL observable."""
         urlchecksum = hashlib.sha256(url_dict["url"].encode("utf-8")).hexdigest()
@@ -154,7 +176,9 @@ class Maltiverse:
             "PUT",
             f"{self.endpoint}/url/{urlchecksum}",
             headers=self._update_headers({"Content-Type": "application/json"}),
-            params=self._prepare_put_params(index_scope=index_scope),
+            params=self._prepare_put_params(
+                index_scope=index_scope, enqueue_ingestion=enqueue_ingestion
+            ),
             data=self.prepare_put_payload(url_dict),
         )
 
@@ -186,14 +210,19 @@ class Maltiverse:
         return self._request("GET", f"{self.endpoint}/sample/sha512/{sha512}")
 
     def sample_put(
-        self, sample_dict: dict, index_scope: t.Optional[T_AdminIndexScope] = None
+        self,
+        sample_dict: dict,
+        index_scope: t.Optional[T_AdminIndexScope] = None,
+        enqueue_ingestion: t.Optional[bool] = None,
     ):
         """Update or insert a sample observable."""
         return self._request(
             "PUT",
             f"{self.endpoint}/sample/{sample_dict['sha256']}",
             headers=self._update_headers({"Content-Type": "application/json"}),
-            params=self._prepare_put_params(index_scope=index_scope),
+            params=self._prepare_put_params(
+                index_scope=index_scope, enqueue_ingestion=enqueue_ingestion
+            ),
             data=self.prepare_put_payload(sample_dict),
         )
 
@@ -206,14 +235,19 @@ class Maltiverse:
         return self._request("GET", f"{self.endpoint}/email/{email_address}")
 
     def email_put(
-        self, email_dict: dict, index_scope: t.Optional[T_AdminIndexScope] = None
+        self,
+        email_dict: dict,
+        index_scope: t.Optional[T_AdminIndexScope] = None,
+        enqueue_ingestion: t.Optional[bool] = None,
     ):
         """Update or insert an email address observable."""
         return self._request(
             "PUT",
             f"{self.endpoint}/email/{email_dict['email_address']}",
             headers=self._update_headers({"Content-Type": "application/json"}),
-            params=self._prepare_put_params(index_scope=index_scope),
+            params=self._prepare_put_params(
+                index_scope=index_scope, enqueue_ingestion=enqueue_ingestion
+            ),
             data=self.prepare_put_payload(email_dict),
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maltiverse"
-version = "1.2.8"
+version = "1.2.9"
 authors = [
   { name="Antonio Gomez", email="antonio.gomez@maltiverse.com" },
   { name="David Gil", email="david.gil@maltiverse.com" },

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name="maltiverse",
     packages=["maltiverse"],
-    version="1.2.8",
+    version="1.2.9",
     license="MIT",
     description="Python API wrapper for Maltiverse",
     author="Antonio Gomez",


### PR DESCRIPTION
Adds support for the new optional IOC PUT query parameter enqueue_ingestion across the Python client.

  ## What changed

  - Extended shared PUT query param builder to accept:
      - enqueue_ingestion: Optional[bool]
  - Updated IOC PUT methods to expose the new optional argument and pass it as a query param when provided:
      - ip_put(...)
      - hostname_put(...)
      - url_put(...)
      - sample_put(...)
      - email_put(...)
  - Preserved existing behavior for index_scope (still admin-gated), while enqueue_ingestion is optional and forwarded when set.

  ## Backward compatibility

  - Non-breaking change.
  - All updated method signatures keep previous parameters and defaults.
  - Existing callers continue to work unchanged.

  ## Validation

  - python3 -m compileall maltiverse
  - Local sanity check confirming:
      - enqueue_ingestion=True is sent in PUT query params
      - index_scope and enqueue_ingestion are both sent together when applicable

  ## Example usage

  api.ip_put(ip_dict, enqueue_ingestion=True)
  api.hostname_put(hostname_dict, index_scope="open", enqueue_ingestion=False)
