### PR TITLE
feat: add buffered bulk upsert support via POST /bulk?buffered=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ From this point request will be sent with authentication JWT parameter if requir
 + email_get()
 + ioc_put()
 + ioc_delete()
++ bulk_upsert_buffered()
 
 ## [2.2 - Generic IOC](#table-of-contents)
 ## [2.2.1 - POST/DELETE](#table-of-contents)
@@ -68,6 +69,54 @@ api.ioc_delete({
     "type": "ip"
 })
 ```
+
+## [2.2.2 - Buffered bulk upsert](#table-of-contents)
+
+`bulk_upsert_buffered` enqueues a batch of indicators into the server-side Redis buffer
+instead of writing directly to Elasticsearch. A Celery beat task flushes the buffer
+roughly every 30 seconds in a single bulk write.
+
+```python
+from maltiverse import Maltiverse, MaltiverseError
+
+api = Maltiverse(auth_token="<admin-token>")
+
+task = api.bulk_upsert_buffered(
+    [
+        {"ip_addr": "1.2.3.4", "type": "ip", "classification": "malicious",
+         "blacklist": [{"description": "C2", "source": "my-feed"}]},
+        {"hostname": "evil.example.com", "type": "hostname",
+         "classification": "malicious",
+         "blacklist": [{"description": "C2", "source": "my-feed"}]},
+    ],
+    index_scope="restricted",   # admins only; omit to use server default
+)
+print(task)  # {"task": "<celery-task-uuid>"}
+```
+
+**When to use buffered vs. direct**
+
+| | Buffered (`bulk_upsert_buffered`) | Direct (`ioc_put` / per-type PUT) |
+|---|---|---|
+| Visibility latency | Up to ~30 s | Immediate |
+| Best for | Large admin/API batch uploads | Interactive or latency-sensitive writes |
+| Duplicate handling | Same indicator within one flush window: counts coalesce, no duplicate document | Each call creates or updates immediately |
+
+**Important notes**
+
+- **Visibility delay** — indicators are not searchable in Elasticsearch until the next
+  Celery beat tick (~30 s worst case).
+- **`index_scope` for platform users** — the server ignores this parameter for
+  non-admin tokens and always writes to the caller's tenant index.
+- **Coalescing** — if you upsert the same indicator multiple times within a single
+  flush window, the server merges them: blacklist `count` values accumulate but only
+  one document is written.
+- **`enrich`** — do not pass `enrich=True`; the server returns 400 for
+  `buffered + enrich`.
+- **Task ID** — the returned `{"task": "..."}` is informational only. There is no
+  progress endpoint for buffered writes.
+- **Error handling** — a `MaltiverseError` is raised on any 4xx/5xx response with
+  `status_code` and `message` attributes.
 
 ## [2.3 - IPv4](#table-of-contents)
 ## [2.3.1 - GET](#table-of-contents)

--- a/maltiverse/__init__.py
+++ b/maltiverse/__init__.py
@@ -1,3 +1,3 @@
-from .maltiverse import Maltiverse
+from .maltiverse import Maltiverse, MaltiverseError
 
-__all__ = ["Maltiverse"]
+__all__ = ["Maltiverse", "MaltiverseError"]

--- a/maltiverse/maltiverse.py
+++ b/maltiverse/maltiverse.py
@@ -11,6 +11,15 @@ import requests
 T_AdminIndexScope = t.Literal["open", "restricted", "showroom"]
 
 
+class MaltiverseError(Exception):
+    """Raised when the Maltiverse API returns a 4xx or 5xx response."""
+
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"HTTP {status_code}: {message}")
+
+
 class Maltiverse:
     def __init__(self, auth_token=None, endpoint="https://api.maltiverse.com"):
         self.endpoint = endpoint
@@ -97,13 +106,24 @@ class Maltiverse:
         self.team_researcher = decoded_payload.get("team_researcher")
         self.admin = decoded_payload.get("admin")
 
-    def _request(self, method, url, headers=None, **kwargs):
+    def _request(self, method, url, headers=None, check_status=False, **kwargs):
         """Make an HTTP request with the specified method."""
         headers = headers or self._default_headers
         # Keep a short timeout so bulk uploads don't stall when backend failures occur.
         if method.upper() == "PUT" and "timeout" not in kwargs:
             kwargs["timeout"] = 2.0
-        return requests.request(method, url, headers=headers, **kwargs).json()
+        response = requests.request(method, url, headers=headers, **kwargs)
+        if check_status and not response.ok:
+            body = {}
+            try:
+                body = response.json()
+            except Exception:
+                pass
+            raise MaltiverseError(
+                response.status_code,
+                body.get("message", response.text),
+            )
+        return response.json()
 
     def ioc_put(
         self,
@@ -134,6 +154,57 @@ class Maltiverse:
             headers=self._update_headers({"Content-Type": "application/json"}),
             params=self._prepare_put_params(index_scope=index_scope),
             data=json.dumps(ioc_dict),
+        )
+
+    def bulk_upsert_buffered(
+        self,
+        indicators: t.List[dict],
+        *,
+        index_scope: t.Optional[T_AdminIndexScope] = None,
+    ) -> dict:
+        """Enqueue a batch of indicators for buffered ingestion via the server-side Redis buffer.
+
+        Writes are coalesced and flushed to Elasticsearch in ~30-second windows by a
+        Celery beat task. Indicators are NOT immediately searchable after this call
+        returns — expect up to ~30 s of visibility latency.
+
+        Use this for large admin/API batch uploads that do not require immediate
+        visibility. Use ioc_put or the per-type PUT methods when writes must appear in
+        search results right away.
+
+        The server does not expose a progress endpoint for buffered writes — the
+        returned task ID is informational only.
+
+        Args:
+            indicators: List of IOC dicts. Accepts the same shapes as ioc_put.
+            index_scope: Target index ("open", "restricted", "showroom"). Honoured only
+                for admin tokens — platform users always write to their tenant index
+                regardless of this value.
+
+        Returns:
+            Parsed JSON, e.g. {"task": "<celery-task-uuid>"}.
+
+        Raises:
+            MaltiverseError: On any 4xx or 5xx response. The server returns 400 for a
+                malformed payload or if enrich=true is passed, and 403 for an
+                unauthorised index_scope.
+
+        Notes:
+            - Repeated upserts for the same indicator within a flush window coalesce:
+              blacklist counts accumulate without creating duplicate documents.
+            - index_scope is a no-op for platform users; the server always uses their
+              tenant index.
+        """
+        params: dict = {"buffered": "true"}
+        if self.admin and index_scope is not None:
+            params["index_scope"] = index_scope
+        return self._request(
+            "POST",
+            f"{self.endpoint}/bulk",
+            headers=self._update_headers({"Content-Type": "application/json"}),
+            params=params,
+            data=json.dumps({"indicators": indicators}),
+            check_status=True,
         )
 
     def ip_get(self, ip_addr):

--- a/maltiverse/test_maltiverse.py
+++ b/maltiverse/test_maltiverse.py
@@ -2,10 +2,11 @@
 # -*- coding: utf-8 -*-
 
 
+import json
 import unittest
 import typing as t
-from unittest.mock import patch
-from maltiverse import Maltiverse
+from unittest.mock import Mock, patch
+from maltiverse import Maltiverse, MaltiverseError
 from maltiverse.maltiverse import T_AdminIndexScope
 import time
 
@@ -237,6 +238,93 @@ class TestMaltiverseIocHelpers(unittest.TestCase):
             kwargs["data"], '{"hostname": "example.com", "type": "hostname"}'
         )
         self.assertEqual(item["status"], "success")
+
+
+class TestBulkUpsertBuffered(unittest.TestCase):
+    """Unit tests for bulk_upsert_buffered."""
+
+    def _admin_client(self):
+        m = Maltiverse()
+        m.admin = True
+        return m
+
+    def test_posts_to_bulk_endpoint_with_buffered_param(self):
+        m = Maltiverse()
+        indicators = [{"ip_addr": "1.1.1.1", "type": "ip"}]
+        with patch.object(m, "_request", return_value={"task": "abc-123"}) as req:
+            result = m.bulk_upsert_buffered(indicators)
+        req.assert_called_once()
+        args, kwargs = req.call_args
+        self.assertEqual(args[0], "POST")
+        self.assertEqual(args[1], "https://api.maltiverse.com/bulk")
+        self.assertEqual(kwargs["params"]["buffered"], "true")
+        self.assertNotIn("index_scope", kwargs["params"])
+        self.assertEqual(result, {"task": "abc-123"})
+
+    def test_index_scope_included_for_admin(self):
+        m = self._admin_client()
+        with patch.object(m, "_request", return_value={"task": "t"}) as req:
+            m.bulk_upsert_buffered([{"ip_addr": "2.2.2.2", "type": "ip"}], index_scope="restricted")
+        _, kwargs = req.call_args
+        self.assertEqual(kwargs["params"]["index_scope"], "restricted")
+
+    def test_index_scope_omitted_for_non_admin(self):
+        m = Maltiverse()
+        m.admin = False
+        with patch.object(m, "_request", return_value={"task": "t"}) as req:
+            m.bulk_upsert_buffered([{"ip_addr": "3.3.3.3", "type": "ip"}], index_scope="restricted")
+        _, kwargs = req.call_args
+        self.assertNotIn("index_scope", kwargs["params"])
+
+    def test_body_serialized_as_indicators_wrapper(self):
+        m = Maltiverse()
+        indicators = [{"ip_addr": "1.1.1.1", "type": "ip"}]
+        with patch.object(m, "_request", return_value={"task": "t"}) as req:
+            m.bulk_upsert_buffered(indicators)
+        _, kwargs = req.call_args
+        self.assertEqual(kwargs["data"], json.dumps({"indicators": indicators}))
+
+    def test_check_status_is_passed_to_request(self):
+        m = Maltiverse()
+        with patch.object(m, "_request", return_value={"task": "t"}) as req:
+            m.bulk_upsert_buffered([{"ip_addr": "1.1.1.1", "type": "ip"}])
+        _, kwargs = req.call_args
+        self.assertTrue(kwargs.get("check_status"))
+
+    def test_raises_maltiverse_error_on_400(self):
+        m = Maltiverse()
+        mock_resp = Mock()
+        mock_resp.ok = False
+        mock_resp.status_code = 400
+        mock_resp.json.return_value = {"status": "fail", "message": "enrich not supported with buffered"}
+        mock_resp.text = "Bad Request"
+        with patch("maltiverse.maltiverse.requests.request", return_value=mock_resp):
+            with self.assertRaises(MaltiverseError) as ctx:
+                m.bulk_upsert_buffered([{"ip_addr": "1.1.1.1", "type": "ip"}])
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("enrich", ctx.exception.message)
+
+    def test_raises_maltiverse_error_on_403(self):
+        m = Maltiverse()
+        mock_resp = Mock()
+        mock_resp.ok = False
+        mock_resp.status_code = 403
+        mock_resp.json.return_value = {"status": "fail", "message": "Forbidden"}
+        mock_resp.text = "Forbidden"
+        with patch("maltiverse.maltiverse.requests.request", return_value=mock_resp):
+            with self.assertRaises(MaltiverseError) as ctx:
+                m.bulk_upsert_buffered([{"ip_addr": "1.1.1.1", "type": "ip"}])
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_returns_task_id_on_202(self):
+        m = Maltiverse()
+        mock_resp = Mock()
+        mock_resp.ok = True
+        mock_resp.status_code = 202
+        mock_resp.json.return_value = {"task": "deadbeef-1234"}
+        with patch("maltiverse.maltiverse.requests.request", return_value=mock_resp):
+            result = m.bulk_upsert_buffered([{"ip_addr": "1.1.1.1", "type": "ip"}])
+        self.assertEqual(result["task"], "deadbeef-1234")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds bulk_upsert_buffered() which enqueues indicators into the server-side Redis buffer (flushed every ~30 s) instead of writing directly to ES, reducing write pressure for large admin/API uploads. Adds MaltiverseError typed exception surfaced on any 4xx/5xx response. Exports MaltiverseError from the package. Docs and unit tests included.