### PR TITLE
feat: default enqueue_ingestion to True in all PUT methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.14
+- Change default value of `enqueue_ingestion` to `True` in all PUT methods (`ip_put`, `hostname_put`, `url_put`, `sample_put`, `email_put`). Previously the parameter was not sent when omitted, causing the server to apply synchronous writes. Pass `enqueue_ingestion=False` explicitly to restore synchronous behaviour.
+
 ## 1.2.13
 - Add `bulk_upsert()` helper that targets the `/bulk` endpoint. The server applies all bulk writes through its buffered ingestion path, so the call is fire-and-forget and indicators appear after a short delay.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ From this point request will be sent with authentication JWT parameter if requir
 + ioc_put()
 + ioc_delete()
 
+> **Note:** All PUT methods default to `enqueue_ingestion=True` (buffered async ingestion). Pass `enqueue_ingestion=False` explicitly if you need synchronous writes.
+
 ## [2.2 - Generic IOC](#table-of-contents)
 ## [2.2.1 - POST/DELETE](#table-of-contents)
 

--- a/maltiverse/maltiverse.py
+++ b/maltiverse/maltiverse.py
@@ -145,7 +145,7 @@ class Maltiverse:
         self,
         ip_dict: dict,
         index_scope: t.Optional[T_AdminIndexScope] = None,
-        enqueue_ingestion: t.Optional[bool] = None,
+        enqueue_ingestion: t.Optional[bool] = True,
     ):
         """Update or insert an IP address observable."""
         return self._request(
@@ -170,7 +170,7 @@ class Maltiverse:
         self,
         hostname_dict: dict,
         index_scope: t.Optional[T_AdminIndexScope] = None,
-        enqueue_ingestion: t.Optional[bool] = None,
+        enqueue_ingestion: t.Optional[bool] = True,
     ):
         """Update or insert a hostname observable."""
         return self._request(
@@ -200,7 +200,7 @@ class Maltiverse:
         self,
         url_dict: dict,
         index_scope: t.Optional[T_AdminIndexScope] = None,
-        enqueue_ingestion: t.Optional[bool] = None,
+        enqueue_ingestion: t.Optional[bool] = True,
     ):
         """Update or insert a URL observable."""
         urlchecksum = hashlib.sha256(url_dict["url"].encode("utf-8")).hexdigest()
@@ -245,7 +245,7 @@ class Maltiverse:
         self,
         sample_dict: dict,
         index_scope: t.Optional[T_AdminIndexScope] = None,
-        enqueue_ingestion: t.Optional[bool] = None,
+        enqueue_ingestion: t.Optional[bool] = True,
     ):
         """Update or insert a sample observable."""
         return self._request(
@@ -270,7 +270,7 @@ class Maltiverse:
         self,
         email_dict: dict,
         index_scope: t.Optional[T_AdminIndexScope] = None,
-        enqueue_ingestion: t.Optional[bool] = None,
+        enqueue_ingestion: t.Optional[bool] = True,
     ):
         """Update or insert an email address observable."""
         return self._request(
@@ -339,11 +339,12 @@ class Maltiverse:
         Indicators may be passed as a list of indicator dicts or as
         ``{"indicators": [...]}``.
 
-        The server applies all bulk writes through its buffered ingestion
-        path: duplicate writes within the coalescing window are merged and
-        indicators are not immediately searchable. Returns the parsed JSON
-        response (typically ``{"task": "<id>"}``); there is no progress
-        endpoint for that task id, so treat the call as fire-and-forget.
+        The server always enqueues bulk writes (``enqueue_ingestion`` is
+        hardcoded to ``True`` server-side): duplicate writes within the
+        coalescing window are merged and indicators are not immediately
+        searchable. Returns the parsed JSON response (typically
+        ``{"task": "<id>"}``); there is no progress endpoint for that task
+        id, so treat the call as fire-and-forget.
 
         ``index_scope`` is admin-only for the ``open``/``restricted``/
         ``showroom`` values; platform users always write to their tenant

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maltiverse"
-version = "1.2.13"
+version = "1.2.14"
 authors = [
   { name="Antonio Gomez", email="antonio.gomez@maltiverse.com" },
   { name="David Gil", email="david.gil@maltiverse.com" },


### PR DESCRIPTION
All type-specific PUT methods (ip_put, hostname_put, url_put, sample_put, email_put) now send enqueue_ingestion=True by default instead of omitting the parameter, which caused the server to apply synchronous writes. Bump version to 1.2.14.